### PR TITLE
Wait for busy line to drop before reading serial

### DIFF
--- a/interface/xtl.py
+++ b/interface/xtl.py
@@ -177,7 +177,9 @@ class XTL:
 
         while self.doListen:
             # get a message if there is one
-            if self.bus.ser.in_waiting:
+            if self.bus.ser.in_waiting > 0:
+                while self.bus.isBusy():
+                    pass
                 # Read rest of message
                 rxMsg = self.bus.read(self.bus.ser.in_waiting)
                 # Put into queue


### PR DESCRIPTION
I was getting short messages, as I was reading the serial line
while it was busy. Not sure if this is due to my RIB or USB to serial.