### PR TITLE
19 pyaudio broken on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ start_debug.sh
 # Custom configs
 config.json
 config_debug.json
+
+# Cert stuff
+certs/private/

--- a/console-client/client.js
+++ b/console-client/client.js
@@ -40,8 +40,9 @@ var audio = {
 var rtc = {
     // Peer connection object
     peer: null,
-    // Audio codec (Opus 48khz stereo)
-    codec: "opus/48000/2"
+    // Audio codec
+    //codec: "opus/48000/2"
+    codec: "PCMU/8000"
 }
 
 testInput = null,
@@ -962,6 +963,10 @@ function sendRtcOffer() {
         var offer = rtc.peer.localDescription;
         offer.sdp = sdpFilterCodec('audio', rtc.codec, offer.sdp);
 
+        // Debug
+        console.debug("SDP offer:");
+        console.debug(offer.sdp);
+
         // Send the offer to the server via WebSocket
         serverSocket.send(
         `{
@@ -1004,6 +1009,8 @@ function gotRtcResponse(answerType, answerSdp) {
  * @returns new SDP using specified codec
  */
 function sdpFilterCodec(kind, codec, realSdp) {
+    console.debug("Non-filtered SDP:");
+    console.debug(realSdp);
     var allowed = []
     var rtxRegex = new RegExp('a=fmtp:(\\d+) apt=(\\d+)\r$');
     var codecRegex = new RegExp('a=rtpmap:([0-9]+) ' + escapeRegExp(codec))

--- a/interface/xtl.py
+++ b/interface/xtl.py
@@ -201,7 +201,7 @@ class XTL:
                 pass
 
             # give the CPU a break
-            time.sleep(0.01)
+            time.sleep(0.05)
 
     def process(self):
         """

--- a/radioClass.py
+++ b/radioClass.py
@@ -391,13 +391,14 @@ class Radio():
 
         # Check if we have a status
         if status:
-            self.logger.logWarn("{} got PyAudio status: {}".format(self.name, status))
+            self.logger.logWarn("{} got PyAudio status: {}".format(self.name, self.getPyaudioCallback(status)))
+            self.logger.logWarn("Mic queue size {}".format(self.spkrQueue.qsize(),self.micQueue.qsize()))
 
         # Start with empty samples
         data = np.zeros(frame_count).astype(np.int16)
 
         # only get samples if there's more than one chunk in the queue
-        if self.micQueue.qsize() > 1:
+        if self.micQueue.qsize() > 0:
             try:
                 data = self.micQueue.get_nowait()
 
@@ -409,7 +410,7 @@ class Radio():
 
     def spkrCallback(self, in_data, frame_count, time_info, status):
         """
-        Callback for radio spkr -> client input device
+        Callback for radio spkr -> client device
         fires whenever new speaker data is available (all the time)
 
         Args:
@@ -420,9 +421,8 @@ class Radio():
         """
 
         # log status if we have one
-        if status:
+        if status and status not in [1,2,4,8]:
             self.logger.logWarn("{} got PyAudio status: {}".format(self.name, self.getPyaudioCallback(status)))
-            self.logger.logWarn("Queue sizes: spkr ({}), mic ({})".format(self.spkrQueue.qsize(),self.micQueue.qsize()))
 
         # only send speaker data if we're receiving and not muted
         if self.state == RadioState.Receiving and not self.muted:


### PR DESCRIPTION
a few updates and fixes to get the console server running on my lightweight debian box:

- added certificate handling to config file to specify ssl certificates, will use localhost certs in `certs/` by default
- changed `time.sleep` calls in threads from 0.01 to 0.05 to reduce CPU usage
- switched to PCMU/8000 codec (G711 mu-law encoding) instead of OPUS to reduce CPU usage