### PR TITLE
Softkey, SB9600, and logging improvements

### DIFF
--- a/Docs/Websocket JSON Signalling.md
+++ b/Docs/Websocket JSON Signalling.md
@@ -82,6 +82,7 @@ These are sent from the client to the server
    - requires a number in the `options` field
 - `button` indicates a button press. `options` specifies the button, valid options are:
    - `softkey1` through `softkey5` requisite softkey (dynamic for O5 control head or static for user-defined buttons)
+   - `left` and `right` for paging through softkeys
 
 ### Audio Control Commands
 

--- a/console-client/index.html
+++ b/console-client/index.html
@@ -123,7 +123,7 @@
                 <div class="topcoat-button-bar">
                     <!-- Left Arrow -->
                     <div class="topcoat-button-bar__item">
-                        <button id="leftarrow" class="topcoat-button-bar__button--large" onclick="softkeys_left()" disabled style="width:48px">
+                        <button id="leftarrow" class="topcoat-button-bar__button--large" onclick="button_left()" disabled style="width:48px">
                             <ion-icon name="caret-back-sharp"></ion-icon>
                         </button>
                     </div>
@@ -159,7 +159,7 @@
                     </div>
                     <!-- Right Arrow -->
                     <div class="topcoat-button-bar__item">
-                        <button id="rightarrow" class="topcoat-button-bar__button--large" onclick="softkeys_right()" disabled style="width:48px">
+                        <button id="rightarrow" class="topcoat-button-bar__button--large" onclick="button_right()" disabled style="width:48px">
                             <ion-icon name="caret-forward-sharp"></ion-icon>
                         </button>
                     </div>

--- a/interface/xtl.py
+++ b/interface/xtl.py
@@ -351,7 +351,8 @@ class XTL:
             msg (byte[]): message array of bytes
         """
 
-        self.logger.logVerbose("SBEP msg {}".format(hexlify(msg, " ")))
+        #self.logger.logVerbose("SBEP msg  {}".format(hexlify(msg, " ")))
+        #self.logger.logVerbose("SBEP text {}".format(msg.decode('ascii','ignore')))
 
         # get important bits
         address = msg[0]
@@ -382,6 +383,10 @@ class XTL:
                     self.chanText = newText
                     self.newStatus = True
                     self.logger.logVerbose("Got new channel text: {}".format(newText))
+                return totalLength
+            elif subdev == self.O5Address.display_subdevs['text_softkeys']:
+                keyText = data.decode('ascii').rstrip().rstrip('\x00').split('^')[1:6]
+                self.logger.logVerbose("Got new softkeys: {}".format(keyText))
                 return totalLength
 
         # Display icon update 

--- a/logger.py
+++ b/logger.py
@@ -12,9 +12,10 @@ class Logger:
         Logging Print Functions
     -------------------------------------------------------------------------------"""
 
-    def __init__(self, verbose=False):
+    def __init__(self, verbose=False, debug=False):
         # Save verbosity
         self.verbose = verbose
+        self.debug = debug
 
     def initLogs(self):
         # Init colorama
@@ -22,6 +23,15 @@ class Logger:
 
     def setVerbose(self, verbose):
         self.verbose = verbose
+
+    def setDebug(self, debug):
+        self.debug = debug
+
+    def logDebug(self, msg):
+        if self.debug:
+            callingFunction = inspect.currentframe().f_back.f_code.co_name
+            timeString = datetime.now().strftime("%m/%d %H:%M:%S.%f")[:-3]
+            print(Fore.BLUE + Style.DIM + "[{}] ({:^16}) DEBG: {}".format(timeString, callingFunction, str(msg)) + Style.RESET_ALL)
 
     def logVerbose(self, msg):
         if self.verbose:

--- a/radioClass.py
+++ b/radioClass.py
@@ -81,11 +81,7 @@ class Radio():
         self.selected = False
         self.muted = False
         self.softkeys = ["","","","",""]
-        self.softkey1 = False
-        self.softkey2 = False
-        self.softkey3 = False
-        self.softkey4 = False
-        self.softkey5 = False
+        self.softkeyStates = [False, False, False, False, False]
 
         # Radio interface class
         self.interface = None
@@ -175,35 +171,17 @@ class Radio():
         """
         self.interface.toggleSoftkey(idx)
 
-    def toggleMonitor(self):
+    def leftArrow(self):
         """
-        Toggles monitor state
+        Scrolls left through softkeys
         """
-        self.interface.toggleMonitor()
+        self.interface.leftArrow()
 
-    def nuisanceDelete(self):
+    def rightArrow(self):
         """
-        Nuisance delete scan
+        Scrolls right through softkeys
         """
-        self.interface.nuisanceDelete()
-
-    def togglePower(self):
-        """
-        Power toggle button
-        """
-        self.interface.togglePower()
-
-    def toggleScan(self):
-        """
-        Toggles state of scan
-        """
-        self.interface.toggleScan()
-
-    def toggleDirect(self):
-        """
-        Toggle state of talkaround
-        """
-        self.interface.toggleDirect()
+        self.interface.rightArrow()
 
     def setMute(self, state):
         """
@@ -227,10 +205,8 @@ class Radio():
         self.state = self.interface.state
         self.chan = self.interface.chanText
         self.zone = self.interface.zoneText
-        self.scanning = self.interface.scanning
-        self.talkaround = self.interface.talkaround
-        self.monitor = self.interface.monitor
-        self.lowpower = self.interface.lowpower
+        self.softkeys = self.interface.softkeys
+        self.softkeyStates = self.interface.softkeyStates
 
     def parseState(self):
         """Return current state of radio
@@ -287,10 +263,8 @@ class Radio():
             "muted": self.muted,
             "error": self.error,
             "errorText": errorText,
-            "scanning": self.scanning,
-            "talkaround": self.talkaround,
-            "monitor": self.monitor,
-            "lowpower": self.lowpower
+            "softkeys": self.softkeys,
+            "softkeyStates": self.softkeyStates
         }
         
         # Return the dict

--- a/server-runtime.py
+++ b/server-runtime.py
@@ -147,6 +147,7 @@ def addArguments():
     parser.add_argument("-nr","--no-reset", help="Don't reset connected radios on start", action="store_true")
     parser.add_argument("-sp","--serverport", help="Websocket server port")
     parser.add_argument("-v","--verbose", help="Enable verbose logging", action="store_true")
+    parser.add_argument("-vv","--verbose2", help="Debug verbosity in logging", action="store_true")
     parser.add_argument("-wc","--webguicert", help="Web GUI certificate for TLS")
     parser.add_argument("-wp","--webguiport", help="Web GUI port")
     parser.add_argument("-cp", "--cpu-profiling", help="Enable yappi CPU profiling", action="store_true")
@@ -168,7 +169,12 @@ def parseArguments():
     # Verbose logging
     if args.verbose:
         logger.setVerbose(args.verbose)
-        logger.logInfo("Verbose logging enabled")
+        logger.logVerbose("Verbose logging enabled")
+
+    if args.verbose2:
+        logger.setVerbose(True)
+        logger.setDebug(True)
+        logger.logDebug("Debug logging enabled")
 
     # List available serial devices
     if args.list_ports:
@@ -325,6 +331,24 @@ def toggleSoftkey(index, softkeyidx):
         softkeyidx (int): Index of softkey (1-5)
     """
     config.RadioList[index].toggleSoftkey(softkeyidx)
+
+def leftArrow(index):
+    """
+    Presses left arrow button (for softkey scrolling)
+
+    Args:
+        index (int): Index of radio in RadioList
+    """
+    config.RadioList[index].leftArrow()
+
+def rightArrow(index):
+    """
+    Presses right arrow button (for softkey scrolling)
+
+    Args:
+        index (int): Index of radio in RadioList
+    """
+    config.RadioList[index].rightArrow()
 
 def toggleMute(index, state):
     """
@@ -787,7 +811,13 @@ async def consumer_handler(websocket, path):
                         # Toggle a softkey
                         if "softkey" in button:
                             softkeyidx = int(button[7])
-                            toggleSoftkey(index, softkeyidx)                            
+                            toggleSoftkey(index, softkeyidx)
+
+                        # Left/right arrow keys
+                        elif button == "left":
+                            leftArrow(index)
+                        elif button == "right":
+                            rightArrow(index)
 
                 #
                 #   Audio Control Messages


### PR DESCRIPTION
Couple of changes to UI and SB9600:

- Switched fixed button controls to softkeys, updated (for now) from O5 control head softkey text. Future plans will allow for user-defined softkeys for radios with fixed softkeys (W4/5/7/9) or no softkeys (XPR, etc)
- Added SB9600 retry system for sending SB9600 commands. This should reduce and prevent lockups when a button press is missed the first time
- Added optional debug log level (accessed by `-vv` or `--verbose2`)