### PR TITLE
Corrects js comment that prevents startup on windows.

### DIFF
--- a/console-client/client.js
+++ b/console-client/client.js
@@ -137,7 +137,7 @@ function connect() {
     $("#navbar-status").addClass("pending");
     // Connect websocket first
     connectWebsocket();
-    // Start audio devices if they're not already started
+    // Start audio devices if they are not already started
     if (!audio.context) {
         startAudioDevices();
     }

--- a/console-client/client.js
+++ b/console-client/client.js
@@ -56,7 +56,8 @@ var audio = {
 // WebRTC Variables
 var rtcConf = {
     // Audio codec
-    codec: "opus/48000/2",  // I've found that OPUS seems to have better latency than PCMU
+    // OPUS seems to have better latency than PCMU
+    codec: "opus/48000/2",
     bitrate: 8000,
     //codec: "PCMU/8000",
     // Total audio round trip time (in ms) (set as const for now, adds delay before muting RX audio and stopping TX)


### PR DESCRIPTION
This comment currently prevents startup on windows due to the apostrophe being interpreted as a string literal. Updates the comment to be more sane.